### PR TITLE
Updated github login that exchanges code to backend for jwt.

### DIFF
--- a/StickerSmash/components/GitHubLogin.tsx
+++ b/StickerSmash/components/GitHubLogin.tsx
@@ -1,6 +1,11 @@
 import React, { useEffect } from "react";
 import { Button, Platform, View } from "react-native";
 import * as AuthSession from "expo-auth-session";
+import * as WebBrowser from "expo-web-browser";
+
+// Required for web
+WebBrowser.maybeCompleteAuthSession();
+
 
 // GitHub OAuth endpoints
 const discovery = {
@@ -22,6 +27,29 @@ if (Platform.OS === 'web') {
 
 console.log("GitHub Client ID:", CLIENT_ID);
 export default function GitHubTestLogin() {
+  const sendCodeToBackend = async (code: string, codeVerifier?: string) => {
+    try {
+      console.log("Sending code to backend:", code);
+      console.log("Using codeVerifier:", codeVerifier);
+
+      const res = await fetch("http://localhost:8080/oauth2/callbackGithub", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ code, codeVerifier }),
+      });
+
+      if (!res.ok) throw new Error(`Backend error: ${res.status}`);
+      const data = await res.json();
+      //await SecureStore.setItemAsync("jwt", data.token)
+      await localStorage.setItem("jwt", data.token);
+      console.log("Backend response:", data);
+
+      return data;
+    } catch (err) {
+      console.error("Error sending code to backend:", err);
+    }
+  };
+
   // Generate the redirect URI with your Expo scheme
   let redirectUri:string | undefined;
   if (Platform.OS === "web") {
@@ -47,19 +75,40 @@ export default function GitHubTestLogin() {
       clientId: CLIENT_ID,
       scopes: ["read:user", "user:email"],
       redirectUri,
+      codeChallengeMethod: AuthSession.CodeChallengeMethod.S256,
     },
     discovery
   );
 
   // Handle response
-  useEffect(() => {
-    if (response?.type === "success") {
-      const code = response.params.code;
-      console.log("GitHub response:", response);
-      console.log("GitHub Code:", code);
-      alert("GitHub Login Success!\n\nCode:\n" + code);
-    }
-  }, [response]);
+  // useEffect(() => {
+  //   if (response?.type === "success") {
+  //     const code = response.params.code;
+  //     console.log("GitHub response:", response);
+  //     console.log("GitHub Code:", code);
+  //     alert("GitHub Login Success!\n\nCode:\n" + code);
+  //   }
+  // }, [response]);
+
+  React.useEffect(() => {
+      if (response?.type === "success" && request) {
+        (async () => {
+          try {
+            console.log("OAuth response:", response);
+            const code = response.params.code;
+            console.log("Authorization code:", code);
+  
+            // Send code + PKCE verifier to backend
+            await sendCodeToBackend(code, request.codeVerifier);
+  
+            // Optional: test backend
+            //await testBackend();
+          } catch (err) {
+            console.error("Error handling OAuth response:", err);
+          }
+        })();
+      }
+    }, [response, request]);
 
   return (
     <View style={{ marginTop: 100, padding: 20 }}>


### PR DESCRIPTION
# Feature: Updated GitHub Login with Backend JWT Exchange

## Description
This pull request updates the GitHub login flow to exchange the authorization code from the frontend directly with the backend. The backend now:

1. Receives the GitHub OAuth authorization code from the frontend.
2. Exchanges the code for an access token from GitHub.
3. Fetches the user's GitHub profile and primary email.
4. Generates a backend JWT for session management.
5. Returns a structured response containing the JWT and user information.

This improves security by keeping the client secret on the server and allows the backend to handle user authentication consistently.

## Changes
- Updated `GithubAuthController` to handle code-to-token exchange.
- Added logic to fetch GitHub user profile and email.
- Integrated `JwtService` to generate backend JWT.
- Returns a unified user object (`email`, `username`, `profile_picture`) along with JWT.

## Testing
- Verified the OAuth code exchange with GitHub test account.
- Confirmed JWT generation and frontend receipt.
- Ensured user profile data is correctly returned.

## Notes
- TODO: Handle cases where users log in with both Google and GitHub using the same email to ensure the correct account is retrieved.